### PR TITLE
fix changelog link to reflect latest changes

### DIFF
--- a/META-INF/plugin.xml
+++ b/META-INF/plugin.xml
@@ -10,7 +10,7 @@
     ]]></description>
 
     <change-notes><![CDATA[
-      Full changelog: https://github.com/afcastano/AutoValuePlugin/blob/release/0.0.6/CHANGELOG.md
+      Full changelog: https://github.com/afcastano/AutoValuePlugin/blob/master/CHANGELOG.md
     ]]>
     </change-notes>
 


### PR DESCRIPTION
Link was incorrectly pointing to 0.0.6 version.